### PR TITLE
Correct rank set in ising_graph

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -23,7 +23,7 @@ mutable struct Cluster
         end
         vlist = intersect(active, vlist)
 
-        L = length(collect(vlist))
+        L = length(vlist)
         cl.h = zeros(L)
         cl.J = zeros(L, L)
 
@@ -31,7 +31,9 @@ mutable struct Cluster
         cl.edges = SimpleEdge[]
 
         rank = get_prop(ig, :rank)
-        cl.rank = rank[1:L]
+        
+        # cl.rank = rank[1:L]
+        cl.rank = zeros(Int, L)
 
         for (i, w) ∈ enumerate(vlist)
             push!(cl.vertices, w => i)

--- a/src/ising.jl
+++ b/src/ising.jl
@@ -61,7 +61,11 @@ Create the Ising spin glass model.
 
 Store extra information
 """
-function ising_graph(instance::Instance, L::Int, sgn::Number=1.0)
+function ising_graph(
+    instance::Instance,
+    L::Int,
+    sgn::Number=1.0,
+    rank_override::Dict{Int, Int}=Dict{Int, Int}())
 
     # load the Ising instance
     if typeof(instance) == String
@@ -103,7 +107,14 @@ function ising_graph(instance::Instance, L::Int, sgn::Number=1.0)
     end
 
     # store extra information
-    set_prop!(ig, :rank, fill(2, L))
+    rank = Dict{Int, Int}()
+    for v in vertices(ig)
+        if get_prop(ig, v, :active)
+            rank[v] = get(rank_override, v, 2)
+        end
+    end
+    
+    set_prop!(ig, :rank, rank)
 
     set_prop!(ig, :J, J)
     set_prop!(ig, :h, h)

--- a/src/ising.jl
+++ b/src/ising.jl
@@ -17,8 +17,7 @@ Calculates matrix elements (probabilities) of \$\\rho\$
 for all possible configurations \$\\σ\$.
 """
 function gibbs_tensor(ig::MetaGraph, β=Float64=1.0)
-    rank = get_prop(ig, :rank)
-    states = collect.(all_states(rank))
+    states = collect.(all_states(rank_vec(ig)))
     ρ = exp.(-β .* energy.(states, Ref(ig)))
     ρ ./ sum(ρ)
 end
@@ -65,7 +64,8 @@ function ising_graph(
     instance::Instance,
     L::Int,
     sgn::Number=1.0,
-    rank_override::Dict{Int, Int}=Dict{Int, Int}())
+    rank_override::Dict{Int, Int}=Dict{Int, Int}()
+)
 
     # load the Ising instance
     if typeof(instance) == String
@@ -76,6 +76,7 @@ function ising_graph(
 
     ig = MetaGraph(L, 0.0)
     set_prop!(ig, :description, "The Ising model.")
+    set_prop!(ig, :L, L)
 
     for v ∈ 1:L
         set_prop!(ig, v, :active, false)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -51,7 +51,7 @@ LinearAlgebra.I(ψ::AbstractMPS, i::Int) = I(size(ψ[i], 2))
 local_basis(d::Int) = union(-1, 1:d-1)
 local_basis(ψ::AbstractMPS, i::Int) = local_basis(size(ψ[i], 2))
 
-function proj(state, dims::T) where {T <: Union{Vector, NTuple}}
+function proj(state, dims::Union{Vector, NTuple})
     P = Matrix{Float64}[] 
     for (σ, r) ∈ zip(state, dims)
         v = zeros(r)
@@ -61,12 +61,12 @@ function proj(state, dims::T) where {T <: Union{Vector, NTuple}}
     P
 end
 
-function all_states(rank::T) where T <: Union{Vector, NTuple}
+function all_states(rank::Union{Vector, NTuple})
     basis = [local_basis(r) for r ∈ rank]
     product(basis...)
 end
 
-function HadamardMPS(rank::T) where T <: Union{Vector, NTuple}
+function HadamardMPS(rank::Union{Vector, NTuple})
     vec = [ fill(1, r) ./ sqrt(r) for r ∈ rank ]
     MPS(vec)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,6 @@
 export idx, ising, proj
 export HadamardMPS, rq
-export all_states, local_basis, enum, state_to_ind
+export all_states, local_basis, enum, state_to_ind, rank_vec
 export @state
 
 using Base.Cartesian
@@ -211,4 +211,10 @@ end
 
         (@nref $N A d->d == dim ? sort!(uniquerows) : (axes(A, d))), indexin(uniquerow, uniquerows)
     end
+end
+
+function rank_vec(ig::MetaGraph)
+    rank = get_prop(ig, :rank)
+    L = get_prop(ig, :L)
+    Int[get(rank, i, 1) for i=1:L]
 end

--- a/test/PEPS.jl
+++ b/test/PEPS.jl
@@ -124,7 +124,7 @@ instance = "$(@__DIR__)/instances/$(L)_001.txt"
 
 ig = ising_graph(instance, L)
 
-states = collect.(all_states(get_prop(ig, :rank)))
+states = collect.(all_states(rank_vec(ig)))
 ρ = exp.(-β .* energy.(states, Ref(ig)))
 Z = sum(ρ)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,7 @@ if CUDA.functional() && CUDA.has_cutensor() && false
 end
 
 push!(my_tests,
-    # "base.jl",
+    "base.jl",
     "utils.jl",
     "contractions.jl",
     "compressions.jl",


### PR DESCRIPTION
This fixes the bug in which `:rank` property of the Ising graph was improperly. Now `:rank` is a `Dict{Int, Int}` which stores a rank for each of spins for which `:active` is `true`. The default rank for each vertex is `2`, but the user can control this via the `rank_override` argument of `ising_graph`. If provided, the vertices specified have the rank equal to the one supplied by the user.

Finally there is a function `rank_vec` which return a `Vector{Int}` containing ranks of each site. For inactive sites the element is equal to `1`.