### PR TITLE
updated spinglass engine to 1.4.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ SpinGlassTensors = "7584fc6a-5a23-4eeb-8277-827aab0146ea"
 
 [compat]
 Reexport = "1.0"
-SpinGlassEngine = "1.3.0"
+SpinGlassEngine = "1.4.0"
 SpinGlassExhaustive = "1.0.0"
 SpinGlassNetworks = "1.2.0"
 SpinGlassTensors = "1.1.3"


### PR DESCRIPTION
We have an old version of the engine right now, and engine tests are failing (the rest is ok).